### PR TITLE
Free memomry taken by objects

### DIFF
--- a/bullet.py
+++ b/bullet.py
@@ -20,7 +20,8 @@ class Bullet(Entity):
             world, 'Bullet', sprite,
             flip=flip,
             speed=Bullet.SPEED,
-            location=location
+            location=location,
+            kill_on_leaving_screen=True
         )
 
     def process(self, time_passed):

--- a/robot.py
+++ b/robot.py
@@ -74,6 +74,7 @@ class RobotStateDodging(State):
 
     def random_destination(self, but=None):
         location = self.robot.get_location()
+        (x, y) = int(location.x), int(location.y)
         range_x = [-200, 200]
         range_y = [-200, 200]
 
@@ -82,8 +83,8 @@ class RobotStateDodging(State):
             range_y[0 if but[1] < 0 else 1] = 0
 
         self.robot.set_destination(Vector(
-            randint(location.x + range_x[0], location.x + range_x[1]),
-            randint(location.y + range_y[0], location.y + range_y[1])
+            randint(x + range_x[0], x + range_x[1]),
+            randint(y + range_y[0], y + range_y[1])
         ))
 
     def do_actions(self):
@@ -157,7 +158,8 @@ class Laser(Entity):
         super(Laser, self).__init__(
             world, 'laser', sprite,
             flip=flip,
-            speed=Laser.SPEED
+            speed=Laser.SPEED,
+            kill_on_leaving_screen=True,
         )
 
     def process(self, time_passed):

--- a/world.py
+++ b/world.py
@@ -37,7 +37,7 @@ class World:
     def detect_collisions(self):
         if (self.entities.get('enemies') and self.entities.get('ally_shots')):
             for enemy in self.entities['enemies']:
-                collisions = pygame.sprite.spritecollide(enemy, self.entities['ally_shots'], True, pygame.sprite.collide_mask)
+                collisions = pygame.sprite.spritecollide(enemy, self.entities['ally_shots'], False, pygame.sprite.collide_mask)
                 if collisions:
                     event = pygame.event.Event(ENEMY_DESTROYED_EVENT, enemy_class=enemy.__class__)
                     pygame.event.post(event)
@@ -45,7 +45,7 @@ class World:
 
         if self.entities.get('enemy_shots') and not settings['debug']:
             for player in self.entities['player']:
-                collisions = pygame.sprite.spritecollide(player, self.entities['enemy_shots'], True, pygame.sprite.collide_mask)
+                collisions = pygame.sprite.spritecollide(player, self.entities['enemy_shots'], False, pygame.sprite.collide_mask)
                 if collisions:
                     if player.receive_hit():
                         player.kill()


### PR DESCRIPTION
Add kill_on_leaving_screen to Entity, to kill automatically sprites that leave screen
Overload kill method of sprite, to release the brain and gc can collect killed Entities

Fixed an issue with location, floats and randint